### PR TITLE
fixes #2

### DIFF
--- a/src/__tests__/interpolation.test.ts
+++ b/src/__tests__/interpolation.test.ts
@@ -48,6 +48,18 @@ describe("linearInterpolate", () => {
 		expect(() => linearInterpolate([1, 0], [4, 5], 3)).toThrowError("Values in the input range have to be strictly monotonically increasing.");
 		expect(() => linearInterpolate([1, 1], [4, 5], 3)).toThrowError("Values in the input range have to be strictly monotonically increasing.");
 	});
+	test("Should extend values that are greater than input range's maximum value", () => {
+		expect(linearInterpolate([5, 10], [50, 100], 11, "extend")).toBe(110)
+	});
+	test("Should clamp values that are greater than input range's maximum value", () => {
+		expect(linearInterpolate([5, 10], [50, 100], 11, "clamp")).toBe(100)
+	});
+	test("Should extend values that are lower than input range's minimum value", () => {
+		expect(linearInterpolate([5, 10], [50, 100], 4, "extend")).toBe(40)
+	});
+	test("Should clamp values that are lower than input range's minimum value", () => {
+		expect(linearInterpolate([5, 10], [50, 100], 4, "clamp")).toBe(50)
+	});
 });
 
 describe("colorInterpolate", () => {

--- a/src/utils/interpolation.util.ts
+++ b/src/utils/interpolation.util.ts
@@ -9,7 +9,7 @@ export function findInterpolationRangeStart(inputRange: Array<number>, solveFor:
 			break;
 		}
 	}
-	return rangeEnd - 1;
+	return rangeEnd === undefined ? inputRange.length - 2 : Math.max(0, rangeEnd - 1);
 }
 
 export function linearInterpolate(inputRange: Array<number>, outputRange: Array<number>, solveFor: number, extrapolate: "clamp" | "extend" = "extend"): number {

--- a/utils/interpolation.util.js
+++ b/utils/interpolation.util.js
@@ -10,7 +10,7 @@ function findInterpolationRangeStart(inputRange, solveFor) {
             break;
         }
     }
-    return rangeEnd - 1;
+    return rangeEnd === undefined ? inputRange.length - 2 : Math.max(0, rangeEnd - 1);
 }
 exports.findInterpolationRangeStart = findInterpolationRangeStart;
 function linearInterpolate(inputRange, outputRange, solveFor, extrapolate) {


### PR DESCRIPTION
Makes `findInterpolationRangeStart` to be able to deal with the exceptional cases of solveFor not being inside inputRange.

## Description
`findInterpolationRangeStart` was not ready to work if solveFor was outside (greater or lower) the inputRange.

## Motivation and Context
Fixes christiandrey/polate-js#2

## How Has This Been Tested?
Jest tests were added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
